### PR TITLE
fix: Windows gcc build error

### DIFF
--- a/src/channel-hub-client.cpp
+++ b/src/channel-hub-client.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "channel-hub-client.hpp"
 #include "channel-hub-protocol.hpp"
 #include "macros/unwrap.hpp"

--- a/src/channel-hub-client.hpp
+++ b/src/channel-hub-client.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <optional>
+
 #include "websocket-session.hpp"
 
 namespace p2p::chub {


### PR DESCRIPTION
- On Windows machine (MingW-W64 builds g++), build failed.
- Adding \<utility\> to the src/channel-hub-client.cpp and \<optional\> to the src/channel-hub-client.hpp resolved this issue.

- Build Error Log
  ```
  PS C:\Users\noda\p2p-sig-sv-gcc-win\p2p-signaling-server> git log -1
  commit 013569ad00eb8e43770c34c87adaaf131cd34932 (HEAD -> main, origin/main, origin/HEAD)
  Author: mojyack <mojyack@gmail.com>
  Date:   Wed Jul 10 16:34:43 2024 +0900
  
      channel-hub: fix responding Success to PadRequestResponse
  PS C:\Users\noda\p2p-sig-sv-gcc-win\p2p-signaling-server> git diff
  PS C:\Users\noda\p2p-sig-sv-gcc-win\p2p-signaling-server> ninja -C debug
  ninja: Entering directory `debug'
  [7/26] Compiling C++ object channel-hub-client-test.exe.p/src_channel-hub-client.cpp.obj
  FAILED: channel-hub-client-test.exe.p/src_channel-hub-client.cpp.obj
  "c++" "-Ichannel-hub-client-test.exe.p" "-I." "-I.." "-IC:/Users/noda/p2p-sig-sv-gcc-win/lib/include" "-IC:/Users/noda/p2p-sig-sv-gcc-win/lib/OpenSSL/lib64/pkgconfig/../../include" "-fdiagnostics-color=always" "-D_GLIBCXX_ASSERTIONS=1" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wextra" "-Wpedantic" "-std=c++20" "-O0" "-g" "-Wfatal-errors" "-Wno-missing-field-initializers" -MD -MQ channel-hub-client-test.exe.p/src_channel-hub-client.cpp.obj -MF "channel-hub-client-test.exe.p\src_channel-hub-client.cpp.obj.d" -o channel-hub-client-test.exe.p/src_channel-hub-client.cpp.obj "-c" ../src/channel-hub-client.cpp
  In file included from ../src/channel-hub-client.cpp:1:
  ../src/channel-hub-client.hpp:35:61: error: 'optional' in namespace 'std' does not name a template type
     35 |     auto request_pad(std::string_view channel_name) -> std::optional<std::string>;
        |                                                             ^~~~~~~~
  compilation terminated due to -Wfatal-errors.
  [8/26] Compiling C++ object channel-hub-client-test.exe.p/example_channel-hub-client-test.cpp.obj
  FAILED: channel-hub-client-test.exe.p/example_channel-hub-client-test.cpp.obj
  "c++" "-Ichannel-hub-client-test.exe.p" "-I." "-I.." "-IC:/Users/noda/p2p-sig-sv-gcc-win/lib/include" "-IC:/Users/noda/p2p-sig-sv-gcc-win/lib/OpenSSL/lib64/pkgconfig/../../include" "-fdiagnostics-color=always" "-D_GLIBCXX_ASSERTIONS=1" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wextra" "-Wpedantic" "-std=c++20" "-O0" "-g" "-Wfatal-errors" "-Wno-missing-field-initializers" -MD -MQ channel-hub-client-test.exe.p/example_channel-hub-client-test.cpp.obj -MF "channel-hub-client-test.exe.p\example_channel-hub-client-test.cpp.obj.d" -o channel-hub-client-test.exe.p/example_channel-hub-client-test.cpp.obj "-c" ../example/channel-hub-client-test.cpp
  In file included from ../example/channel-hub-client-test.cpp:2:
  ../example/p2p/channel-hub-client.hpp:35:61: error: 'optional' in namespace 'std' does not name a template type
     35 |     auto request_pad(std::string_view channel_name) -> std::optional<std::string>;
        |                                                             ^~~~~~~~
  compilation terminated due to -Wfatal-errors.
  [20/26] Compiling C++ object channel-hub-client-test.exe.p/src_ws_impl.cpp.obj
  ninja: build stopped: subcommand failed.
  ```
  - After added \#include \<optional\>
  ```
  PS C:\Users\noda\p2p-sig-sv-gcc-win\p2p-signaling-server> git diff
  diff --git a/src/channel-hub-client.hpp b/src/channel-hub-client.hpp
  index c366be2..0cb4a0f 100644
  --- a/src/channel-hub-client.hpp
  +++ b/src/channel-hub-client.hpp
  @@ -1,4 +1,6 @@
   #pragma once
  +#include <optional>
  +
   #include "websocket-session.hpp"
  
   namespace p2p::chub {
  PS C:\Users\noda\p2p-sig-sv-gcc-win\p2p-signaling-server> ninja -C debug
  ninja: Entering directory `debug'
  [1/16] Compiling C++ object channel-hub-client-test.exe.p/src_channel-hub-client.cpp.obj
  FAILED: channel-hub-client-test.exe.p/src_channel-hub-client.cpp.obj
  "c++" "-Ichannel-hub-client-test.exe.p" "-I." "-I.." "-IC:/Users/noda/p2p-sig-sv-gcc-win/lib/include" "-IC:/Users/noda/p2p-sig-sv-gcc-win/lib/OpenSSL/lib64/pkgconfig/../../include" "-fdiagnostics-color=always" "-D_GLIBCXX_ASSERTIONS=1" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wextra" "-Wpedantic" "-std=c++20" "-O0" "-g" "-Wfatal-errors" "-Wno-missing-field-initializers" -MD -MQ channel-hub-client-test.exe.p/src_channel-hub-client.cpp.obj -MF "channel-hub-client-test.exe.p\src_channel-hub-client.cpp.obj.d" -o channel-hub-client-test.exe.p/src_channel-hub-client.cpp.obj "-c" ../src/channel-hub-client.cpp
  ../src/channel-hub-client.cpp: In member function 'virtual bool p2p::chub::ChannelHubReceiver::on_packet_received(std::span<const std::byte>)':
  ../src/channel-hub-client.cpp:82:18: error: 'exchange' is not a member of 'std'
     82 |         if(!std::exchange(channels_buffer, channels).empty()) {
        |                  ^~~~~~~~
  compilation terminated due to -Wfatal-errors.
  [12/16] Compiling C++ object channel-hub-client-test.exe.p/src_ws_client.cpp.obj
  ninja: build stopped: subcommand failed.
  ```
  - Add \<optional\> and \<utility\>
  ```
    PS C:\Users\noda\p2p-sig-sv-gcc-win\p2p-signaling-server> git diff
  diff --git a/src/channel-hub-client.cpp b/src/channel-hub-client.cpp
  index 14f6e5b..cc82ba5 100644
  --- a/src/channel-hub-client.cpp
  +++ b/src/channel-hub-client.cpp
  @@ -1,3 +1,5 @@
  +#include <utility>
  +
   #include "channel-hub-client.hpp"
   #include "channel-hub-protocol.hpp"
   #include "macros/unwrap.hpp"
  diff --git a/src/channel-hub-client.hpp b/src/channel-hub-client.hpp
  index c366be2..0cb4a0f 100644
  --- a/src/channel-hub-client.hpp
  +++ b/src/channel-hub-client.hpp
  @@ -1,4 +1,6 @@
   #pragma once
  +#include <optional>
  +
   #include "websocket-session.hpp"
  
   namespace p2p::chub {
  PS C:\Users\noda\p2p-sig-sv-gcc-win\p2p-signaling-server> ninja -C debug
  ninja: Entering directory `debug'
  [14/14] Linking target channel-hub.exe
  PS C:\Users\noda\p2p-sig-sv-gcc-win\p2p-signaling-server>
  ```

- I tested that this PR also works on WSL2 Ubuntu.
```
noda@DESKTOP-OCD63B8 ~/test/p2p-sig-sv-gcc/p2p-signaling-server (main) $ meson setup debug && ninja -C debug
The Meson build system
Version: 0.61.2
Source dir: /home/noda/test/p2p-sig-sv-gcc/p2p-signaling-server
Build dir: /home/noda/test/p2p-sig-sv-gcc/p2p-signaling-server/debug
Build type: native build
Project name: app
Project version: 1.0.0
C++ compiler for the host machine: c++ (gcc 11.4.0 "c++ (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0")
C++ linker for the host machine: c++ ld.bfd 2.38
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: /usr/bin/pkg-config (0.29.2)
Dependency libwebsockets found: NO found 4.0.20 but need: '>=4.3.2'
Found CMake: /usr/bin/cmake (3.22.1)
Run-time dependency libwebsockets found: YES 4.3.3-v4.3.3
Run-time dependency libjuice found: YES 1.0.0
Build targets in project: 4

Found ninja-1.10.1 at /usr/bin/ninja
ninja: Entering directory `debug'
[26/26] Linking target channel-hub-client-test
noda@DESKTOP-OCD63B8 ~/test/p2p-sig-sv-gcc/p2p-signaling-server (main) $ echo $?
0
noda@DESKTOP-OCD63B8 ~/test/p2p-sig-sv-gcc/p2p-signaling-server (main) $ git log -1
commit 88aa4e865000b7c82c9e97caaebaa7aedb27e5f9 (HEAD -> main, origin/main, origin/HEAD)
Author: Kohei Noda <ponserviceregist@gmail.com>
Date:   Thu Jul 11 05:55:28 2024 +0000

    fix: Windows gcc build error
```